### PR TITLE
Support excluding workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ where `4567` is the port on docker host you'd like to expose exporter service to
 rq_enqueued_jobs        gauge   The total number of enqueued jobs (labels: queue_name)
 rq_workers              gauge   The number of workers performing jobs (labels: name, queues, state)
 ```
+
+You can skip scraping `rq_workers` metric by setting the environment variable
+`RQPE_SCRAPE_WORKERS` to anything else then `true`, `yes`, `t` or `1`. This is
+useful in the scenarios you are running RQ workers on preemtible nodes where
+new spawned workers get new unique hostnames each time.
+
 While it's good enough for setting up basic monitoring and alerting in Prometheus, in future would be good to comeback to this and check how to extend it with more metrics
 
 ## Development & Testing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,4 @@ services:
       - redis
 
   redis:
-    image: redis:3.0.2
+    image: redis:3.0.7

--- a/stats_test.py
+++ b/stats_test.py
@@ -1,5 +1,5 @@
 import stats
-from rq import Worker, Queue, Connection
+from rq import Worker, Queue
 
 queue = Queue("echo", connection=stats.CONN)
 worker = Worker(["searches", "test"], name="test_worker", connection=stats.CONN)
@@ -8,11 +8,29 @@ def teardown_function():
     queue.delete(delete_jobs=True)
     worker.register_death()
 
-def test_stat_scrape():
+def test_stat_scrape_default():
     queue.enqueue("echo_worker", "HEY!")
     queue.enqueue("echo_worker", "HO!")
     worker.register_birth()
 
+    jobs, workers = stats.scrape()
+    assert jobs == [{"queue_name": "echo", "size": 2}]
+    assert workers == [{"name": "test_worker", "queues": "searches,test", "state": "?"}]
+
+def test_stat_scrape_disabled_workers_scraping():
+    queue.enqueue("echo_worker", "HEY!")
+    queue.enqueue("echo_worker", "HO!")
+    worker.register_birth()
+    stats.SCRAPE_WORKERS = False
+    jobs, workers = stats.scrape()
+    assert jobs == [{"queue_name": "echo", "size": 2}]
+    assert workers == []
+
+def test_stat_scrape_enabled_workers_scraping():
+    queue.enqueue("echo_worker", "HEY!")
+    queue.enqueue("echo_worker", "HO!")
+    worker.register_birth()
+    stats.SCRAPE_WORKERS = True
     jobs, workers = stats.scrape()
     assert jobs == [{"queue_name": "echo", "size": 2}]
     assert workers == [{"name": "test_worker", "queues": "searches,test", "state": "?"}]


### PR DESCRIPTION
For our use case we run RQ in GCP (Google Cloud Platform) with pods
running on preemtible nodes in Kubernetes, which means new workes
arrives and goes at will. Since each new spawned pod will have it's own
new unique hostname, we will be flooding our prometheus server with
useless metrics.

This feature allows us to avoid flooing our prometheus server with
useless metrics.

Default behavior is to scrape this metrics, just as before.

You can disable this metric with setting the environment varaible
`RQPE_SCRAPE_WORKERS` to anything else then `true`, `yes`, `t` or `1`.
